### PR TITLE
Remove 'ms' from response_time

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ fn = function (req, res, next) {
         res.end(chunk, encoding);
 
         requestToLog.status = res.statusCode;
-        requestToLog.response_time = (new Date() - req._startTime) + 'ms';
+        requestToLog.response_time = (new Date() - req._startTime);
 
         loggers.forEach(function (arr) {
             var logger = arr[0],


### PR DESCRIPTION
The 'ms' part of the response_time makes it more difficult to parse as a number, which makes searches against it difficult. It should be merely implicit
