### PR TITLE
Bugfix: Incomplete URLs logged with nulls

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,19 @@ fn = function (req, res, next) {
         urlToLog = req.originalUrl;
     } else {
         var oUrl = url.parse(req.originalUrl);
-        urlToLog = oUrl.protocol + '//' + oUrl.host + oUrl.pathname;
+        urlToLog = oUrl.pathname;
+
+        if (oUrl.host) {
+          if (oUrl.port) {
+            urlToLog = ':' + oUrl.port + urlToLog;
+          }
+
+          urlToLog = oUrl.host + urlToLog;
+
+          if (oUrl.protocol) {
+            urlToLog = oUrl.protocol + '//' + urlToLog;
+          }
+        }
     }
     var requestEnd = res.end,
         requestToLog = {

--- a/test.js
+++ b/test.js
@@ -73,4 +73,35 @@ describe('Churchill', function(){
 
     });
 
+    describe('when the the url is not complete', function () {
+
+      beforeEach(function () {
+        req.originalUrl = '/myroute?queryParam=queryParamValue&queryParam2=queryParamValue2';
+      });
+
+      it('logs request without the get params if configured to do so', function () {
+
+          var logSpy = sinon.spy();
+
+          churchill.options.logGetParams = false;
+          churchill.add({
+              log: logSpy
+          })(req, res, next);
+
+          res.end();
+
+          var responseTime = logSpy.lastCall.args[1].response_time;
+
+          logSpy.should.have.been.calledWith('info', {
+              method: 'GET',
+              status: 200,
+              response_time: responseTime,
+              url: '/myroute',
+              content_length: '100'
+          });
+
+      });
+
+    });
+
 });


### PR DESCRIPTION
There is currently a bug in which URLs can be logged out as
"null//null/path/to/endpoint" when logGetParams is set to false.

This commit fixes this behaviour by only adding the host and protocol
to the urlToLog when they are present.