### PR TITLE
Log to all loggers on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ npm test
 
 Usage
 ----
-```
+```js
 var churchill = require('churchill');
 app.use(require('churchill')(winston));
 ```
 
 Specify a log level
-```
+```js
 app.use(require('churchill')(winston, 'express'));
 ```
 
@@ -36,16 +36,24 @@ app.use(require('churchill').add(logger, 'express').add(logger, 'someOtherLogLev
 ```
 
 ```req.logger```
-If only one logger is added to churchill then it will be automatically added to req.logger (if its undefined)
+The first logger will be automatically added to req.logger
 This then gives you the facility to use the logger from req like so:
-```
+```js
 req.logger.log('something in winston');
 req.logger.error('Oh noe!');
 ```
+
+```req.log```
+Churchill will also add a `log` method to the request object, which will log to all mounted loggers:
+```js
+req.log('info', 'something in winston');
+req.log('error', 'OH NO!');
+```
+
 To disable this set reqLogger to false in the options.
 
 Formatting
-```
+```js
 var logger = new (winston.Logger).....
 app.use(require('churchill').add(logger, 'express').format(function (obj, req, res) {
   obj.somethingInteresting = req.params.moreData;
@@ -53,7 +61,7 @@ app.use(require('churchill').add(logger, 'express').format(function (obj, req, r
 ```
 
 Suppressing GET params from logs
-```
+```js
 var churchill = require('churchill')
 churchill.options.logGetParams = false
 ```

--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ var url = require('url'),
         };
         return fn;
     },
+    log = function () {
+        var args = arguments;
+        loggers.forEach(logger => logger[0].log.apply(logger[0], args));
+    }
     loggers = [],
     fn,
     Churchill;
@@ -72,10 +76,10 @@ fn = function (req, res, next) {
         });
     };
 
-    if (Churchill.options.reqLogger && req.logger === undefined) {
-        req.logger = function () {
-            const args = arguments;
-            loggers.forEach((logger) => logger[0].apply(logger[0], args));
+    if (Churchill.options.reqLogger) {
+        req.log = log;
+        if (loggers.length && req.logger === undefined) {
+            req.logger = loggers[0][0];
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -72,8 +72,11 @@ fn = function (req, res, next) {
         });
     };
 
-    if (Churchill.options.reqLogger && loggers.length === 1 && req.logger === undefined) {
-        req.logger = loggers[0][0];
+    if (Churchill.options.reqLogger && req.logger === undefined) {
+        req.logger = function () {
+            const args = arguments;
+            loggers.forEach((logger) => logger[0].apply(logger[0], args));
+        }
     }
 
     next();


### PR DESCRIPTION
Instead of only setting `req.logger` when a single logger has been mounted, which is susceptible to error if `req.logger` is assumed to exist, and an additional logger is mounted.

Instead allow `req.logger` to be set if *at least one* logger is mounted (defaulting to the first).

Also add a `req.log` method, which will call through to the `.log` method on *all* mounted loggers.