### PR TITLE
Add request id to logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var random = require('random-string');
+
 var options = {
     logGetParams: true,
     reqLogger: true
@@ -27,6 +29,9 @@ var url = require('url'),
     Churchill;
 
 fn = function (req, res, next) {
+
+    req._loggerToken = random();
+
     var urlToLog;
     if (Churchill.options.logGetParams) {
         urlToLog = req.originalUrl;
@@ -50,7 +55,8 @@ fn = function (req, res, next) {
         requestToLog = {
             status: null,
             method: req.method,
-            url: urlToLog
+            url: urlToLog,
+            id: req._loggerToken
         };
 
     //if we're using a connect middleware logger this will already exist
@@ -78,7 +84,10 @@ fn = function (req, res, next) {
     };
 
     if (Churchill.options.reqLogger) {
-        req.log = log;
+        req.log = function () {
+            var args = [].concat(arguments).concat([{ id: req._loggerToken }]);
+            log.apply(null, args);
+        }
         if (loggers.length && req.logger === undefined) {
             req.logger = loggers[0][0];
         }

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "sinon": "1.7.3",
     "sinon-chai": "2.4.0"
   },
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "random-string": "^0.2.0"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -40,13 +40,13 @@ describe('Churchill', function(){
 
         var responseTime = logSpy.lastCall.args[1].response_time;
 
-        logSpy.should.have.been.calledWith('info', {
+        logSpy.should.have.been.calledWith('info', sinon.match({
             method: 'GET',
             status: 200,
             response_time: responseTime,
             url: 'http://imaurl.com/myroute?queryParam=queryParamValue&queryParam2=queryParamValue2',
             content_length: '100'
-        });
+        }));
 
     });
 
@@ -63,13 +63,13 @@ describe('Churchill', function(){
 
         var responseTime = logSpy.lastCall.args[1].response_time;
 
-        logSpy.should.have.been.calledWith('info', {
+        logSpy.should.have.been.calledWith('info', sinon.match({
             method: 'GET',
             status: 200,
             response_time: responseTime,
             url: 'http://imaurl.com/myroute',
             content_length: '100'
-        });
+        }));
 
     });
 
@@ -92,13 +92,13 @@ describe('Churchill', function(){
 
           var responseTime = logSpy.lastCall.args[1].response_time;
 
-          logSpy.should.have.been.calledWith('info', {
+          logSpy.should.have.been.calledWith('info', sinon.match({
               method: 'GET',
               status: 200,
               response_time: responseTime,
               url: '/myroute',
               content_length: '100'
-          });
+          }));
 
       });
 


### PR DESCRIPTION
This allows logs from a single request to be traced through log files.